### PR TITLE
Split macro into type and at-fused

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiBroadcastFusion"
 uuid = "c3c07f87-98de-43f2-a76f-835b330b2cbb"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.1.1"
+version = "0.2.0"
 
 [compat]
 julia = "^1.10"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ With this package, we can apply `@fused` to reduce the number of reads and prese
 ```julia
 import MultiBroadcastFusion as MBF
 
+MBF.@make_type FusedMultiBroadcast
 MBF.@make_fused FusedMultiBroadcast fused
 # Now, `@fused` will call `Base.copyto!(::FusedMultiBroadcast)`. Let's define it:
 function Base.copyto!(fmb::FusedMultiBroadcast)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -24,6 +24,7 @@ device(x) = GPU()
 # WARNING:
 #    If you've updated `Base.copyto!(fmb::FusedMultiBroadcast)`,
 #    then Revise will not update this method!!!
+MBF.@make_type FusedMultiBroadcast
 MBF.@make_fused FusedMultiBroadcast fused
 if !hasmethod(Base.copyto!, Tuple{<:FusedMultiBroadcast})
     function Base.copyto!(fmb::FusedMultiBroadcast)


### PR DESCRIPTION
Closes #14. This is technically a breaking change, but it's an easy fix on the user side.