### PR TITLE
Generalize `@make_fused`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Users can write custom implementations, using the `@make_type` and `@make_fused`
 import MultiBroadcastFusion as MBF
 
 MBF.@make_type MyFusedMultiBroadcast
-MBF.@make_fused MyFusedMultiBroadcast my_fused
+MBF.@make_fused MBF.fused_pairs MyFusedMultiBroadcast my_fused
 # Now, `@fused` will call `Base.copyto!(::MyFusedMultiBroadcast)`. Let's define it:
 function Base.copyto!(fmb::MyFusedMultiBroadcast)
     pairs = fmb.pairs

--- a/src/collection/fused_pairs.jl
+++ b/src/collection/fused_pairs.jl
@@ -17,6 +17,28 @@ function transform(e::Expr)
     end
 end
 
+"""
+    fused_pairs
+
+Function that fuses broadcast expressions that
+are immediately one after another. For example:
+
+```julia
+import MultiBroadcastFusion as MBF
+MBF.@make_type MyFusedMultiBroadcast
+MBF.@make_fused fused_pairs MyFusedMultiBroadcast fused
+```
+
+To use `MultiBroadcastFusion`'s `@fused` macro:
+```
+import MultiBroadcastFusion as MBF
+x = rand(1);y = rand(1);z = rand(1);
+MBF.@fused begin
+    @. x += y
+    @. z += y
+end
+```
+"""
 function fused_pairs(expr::Expr)
     check_restrictions(expr)
     e = transform(expr)

--- a/src/collection/fused_pairs_flexible.jl
+++ b/src/collection/fused_pairs_flexible.jl
@@ -17,6 +17,28 @@ function transform_flex(e::Expr, sym)
     end
 end
 
+"""
+    fused_pairs_flexible
+
+Function that fuses broadcast expressions
+that stride flow control logic. For example:
+
+```julia
+import MultiBroadcastFusion as MBF
+MBF.@make_type MyFusedMultiBroadcast
+MBF.@make_fused fused_pairs_flexible MyFusedMultiBroadcast fused_flexible
+```
+
+To use `MultiBroadcastFusion`'s `@fused_flexible` macro:
+```
+import MultiBroadcastFusion as MBF
+x = rand(1);y = rand(1);z = rand(1);
+MBF.@fused_flexible begin
+    @. x += y
+    @. z += y
+end
+```
+"""
 function fused_pairs_flexible(expr::Expr, sym::Symbol)
     check_restrictions_flexible(expr)
     e = transform_flex(expr, sym)

--- a/src/collection/macros.jl
+++ b/src/collection/macros.jl
@@ -2,23 +2,23 @@
     @make_type type_name
 
 This macro defines a type `type_name`, to be
-passed to `@make_fused` or `@make_fused_flexible`.
+passed to `@make_fused`.
 """
 macro make_type(type_name)
     t = esc(type_name)
     return quote
-        struct $t{T <: Tuple}
+        struct $t{T <: Union{Tuple, AbstractArray}}
             pairs::T
         end
     end
 end
 
 """
-    @make_fused type_name fused_named
+    @make_fused fusion_type type_name fused_named
 
 This macro
- - Imports MultiBroadcastFusion
- - Defines a macro, `@fused_name`
+ - Defines a type type_name
+ - Defines a macro, `@fused_name`, using the fusion type `fusion_type`
 
 This allows users to flexibility
 to customize their broadcast fusion.
@@ -27,7 +27,7 @@ to customize their broadcast fusion.
 ```julia
 import MultiBroadcastFusion as MBF
 MBF.@make_type MyFusedBroadcast
-MBF.@make_fused MyFusedBroadcast my_fused
+MBF.@make_fused MBF.fused_pairs MyFusedBroadcast my_fused
 
 Base.copyto!(fmb::MyFusedBroadcast) = println("You're ready to fuse!")
 
@@ -42,55 +42,12 @@ y2 = rand(3,3)
 end
 ```
 """
-macro make_fused(type_name, fused_name)
+macro make_fused(fusion_type, type_name, fused_name)
     t = esc(type_name)
     f = esc(fused_name)
     return quote
         macro $f(expr)
-            _pairs = esc($(fused_pairs)(expr))
-            t = $t
-            quote
-                Base.copyto!($t($_pairs))
-            end
-        end
-    end
-end
-
-"""
-    @make_fused_flexible type_name fused_named
-
-This macro
- - Imports MultiBroadcastFusion
- - Defines a macro, `@fused_name`
-
-This allows users to flexibility
-to customize their broadcast fusion.
-
-# Example
-```julia
-import MultiBroadcastFusion as MBF
-MBF.@make_type MyFusedBroadcast
-MBF.@make_fused_flexible MyFusedBroadcast my_fused
-
-Base.copyto!(fmb::MyFusedBroadcast) = println("You're ready to fuse!")
-
-x1 = rand(3,3)
-y1 = rand(3,3)
-y2 = rand(3,3)
-
-# 4 reads, 2 writes
-@my_fused begin
-  @. y1 = x1
-  @. y2 = x1
-end
-```
-"""
-macro make_fused_flexible(type_name, fused_name)
-    t = esc(type_name)
-    f = esc(fused_name)
-    return quote
-        macro $f(expr)
-            _pairs = esc($(fused_pairs_flexible)(expr, gensym()))
+            _pairs = esc($(fusion_type)(expr))
             t = $t
             quote
                 Base.copyto!($t($_pairs))

--- a/src/execution/fused_kernels.jl
+++ b/src/execution/fused_kernels.jl
@@ -1,5 +1,6 @@
 @make_type FusedMultiBroadcast
-@make_fused FusedMultiBroadcast fused
+@make_fused fused_pairs FusedMultiBroadcast fused
+@make_fused fused_pairs_flexible FusedMultiBroadcast fused_flexible
 
 struct CPU end
 struct GPU end


### PR DESCRIPTION
This helps to avoid duplicating the `make_fused` macro for every collection type.