### PR TITLE
Split unit tests from benchmarks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,15 +39,35 @@ steps:
 
       - label: "CPU tests"
         key: tests_cpu
-        command: "julia --color=yes --project=.buildkite test/runtests.jl"
+        command: "julia --color=yes --check-bounds=yes --project=.buildkite test/runtests.jl"
 
       - label: "CUDA tests"
         key: tests_cuda
         command:
           - "julia --project=.buildkite -e 'using CUDA; CUDA.versioninfo()'"
+          - "julia --color=yes --check-bounds=yes --project=.buildkite test/runtests.jl"
+        env:
+          USE_CUDA: "true"
+        agents:
+          slurm_gpus: 1
+
+  - group: "Benchmarks"
+    steps:
+
+      - label: "CPU benchmarks"
+        key: bm_cpu
+        command: "julia --color=yes --project=.buildkite test/runtests.jl"
+        env:
+          PERFORM_BENCHMARK: "true"
+
+      - label: "CUDA benchmarks"
+        key: bm_cuda
+        command:
+          - "julia --project=.buildkite -e 'using CUDA; CUDA.versioninfo()'"
           - "julia --color=yes --project=.buildkite test/runtests.jl"
         env:
           USE_CUDA: "true"
+          PERFORM_BENCHMARK: "true"
         agents:
           slurm_gpus: 1
 

--- a/test/execution/bm_fused_reads_vs_hard_coded.jl
+++ b/test/execution/bm_fused_reads_vs_hard_coded.jl
@@ -90,13 +90,15 @@ problem_size = (50, 5, 5, 6, 5400)
 array_size = problem_size # array
 X = get_arrays(:x, AType, bm.float_type, array_size)
 Y = get_arrays(:y, AType, bm.float_type, array_size)
-test_kernel!(;
+test_kernel!(
+    use_cuda;
     fused! = perf_kernel_fused!,
     unfused! = perf_kernel_unfused!,
     X,
     Y,
 )
-use_cuda && test_kernel!(;
+use_cuda && test_kernel!(
+    use_cuda;
     fused! = perf_kernel_hard_coded!,
     unfused! = perf_kernel_unfused!,
     X,
@@ -133,13 +135,15 @@ use_cuda && push_benchmark!(
 array_size = (prod(problem_size),) # vector
 X = get_arrays(:x, AType, bm.float_type, array_size)
 Y = get_arrays(:y, AType, bm.float_type, array_size)
-test_kernel!(;
+test_kernel!(
+    use_cuda;
     fused! = perf_kernel_fused!,
     unfused! = perf_kernel_unfused!,
     X,
     Y,
 )
-use_cuda && test_kernel!(;
+use_cuda && test_kernel!(
+    use_cuda;
     fused! = perf_kernel_hard_coded!,
     unfused! = perf_kernel_unfused!,
     X,

--- a/test/execution/bm_fused_shared_reads.jl
+++ b/test/execution/bm_fused_shared_reads.jl
@@ -38,7 +38,8 @@ problem_size = (50, 5, 5, 6, 5400)
 array_size = problem_size # array
 X = get_arrays(:x, AType, bm.float_type, array_size)
 Y = get_arrays(:y, AType, bm.float_type, array_size)
-test_kernel!(;
+test_kernel!(
+    use_cuda;
     fused! = perf_kernel_shared_reads_fused!,
     unfused! = perf_kernel_shared_reads_unfused!,
     X,
@@ -66,7 +67,8 @@ push_benchmark!(
 array_size = (prod(problem_size),) # vector
 X = get_arrays(:x, AType, bm.float_type, array_size)
 Y = get_arrays(:y, AType, bm.float_type, array_size)
-test_kernel!(;
+test_kernel!(
+    use_cuda;
     fused! = perf_kernel_shared_reads_fused!,
     unfused! = perf_kernel_shared_reads_unfused!,
     X,

--- a/test/execution/bm_fused_shared_reads_writes.jl
+++ b/test/execution/bm_fused_shared_reads_writes.jl
@@ -42,7 +42,8 @@ problem_size = (50, 5, 5, 6, 5400)
 array_size = problem_size # array
 X = get_arrays(:x, AType, bm.float_type, array_size)
 Y = get_arrays(:y, AType, bm.float_type, array_size)
-test_kernel!(;
+test_kernel!(
+    use_cuda;
     unfused! = perf_kernel_shared_reads_writes_unfused!,
     fused! = perf_kernel_shared_reads_writes_fused!,
     X,
@@ -71,7 +72,8 @@ push_benchmark!(
 array_size = (prod(problem_size),) # vector
 X = get_arrays(:x, AType, bm.float_type, array_size)
 Y = get_arrays(:y, AType, bm.float_type, array_size)
-test_kernel!(;
+test_kernel!(
+    use_cuda;
     unfused! = perf_kernel_shared_reads_writes_unfused!,
     fused! = perf_kernel_shared_reads_writes_fused!,
     X,

--- a/test/execution/utils_benchmark.jl
+++ b/test/execution/utils_benchmark.jl
@@ -60,6 +60,11 @@ trunc_time(s::String) = count(',', s) > 1 ? join(split(s, ",")[1:2], ",") : s
 
 import PrettyTables
 function tabulate_benchmark(bm)
+    perform_benchmark = get(ENV, "PERFORM_BENCHMARK", false) == "true"
+    if !perform_benchmark
+        @warn "Benchmark skipped, set `ENV[\"PERFORM_BENCHMARK\"] = true` to run benchmarks"
+        return nothing
+    end
     funcs = map(x -> strip(x.caller), bm.data)
     timings = map(x -> time_and_units_str(x.kernel_time_s), bm.data)
     n_reads_writes = map(x -> x.n_reads_writes, bm.data)
@@ -159,6 +164,11 @@ function benchmark_trial!(use_cuda, f!, X, Y)
 end
 
 function push_benchmark!(bm, use_cuda, f!, X, Y; n_reads_writes, problem_size)
+    perform_benchmark = get(ENV, "PERFORM_BENCHMARK", false) == "true"
+    if !perform_benchmark
+        @warn "Benchmark skipped, set `ENV[\"PERFORM_BENCHMARK\"] = true` to run benchmarks"
+        return nothing
+    end
     f!(X, Y) # compile first
     trial = benchmark_trial!(use_cuda, f!, X, Y)
     e = minimum(trial.times) * 1e-9 # to seconds


### PR DESCRIPTION
Closes #41. This also fixes a bug: now we use `CartesianIndices(axes(dest))`, and ensure destinations all have the same axes, this ensures that we're correctly traversing memory and spanning the space. Closes #40.