### PR TITLE
Apply a few fixes

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,10 @@
 #=
+julia --project
+using TestEnv
+TestEnv.activate()
+using CUDA;
+ENV["PERFORM_BENCHMARK"]="true";
+
 using Revise; include(joinpath("test", "collection", "runtests.jl"))
 using Revise; include(joinpath("test", "execution", "runtests.jl"))
 using Revise; include(joinpath("test", "runtests.jl"))


### PR DESCRIPTION
In this PR, we:
 - Use the occupancy API to determine the thread-block
 - Add `@inbounds` in the kernel
 - Use `Int32` for the thread index computation
 - Apply lower-bound in addition to upper bound when validating the thread index (`1 ≤ idx ≤ nitems`)
 - Instantiate the broadcast object, so that axes are defined inside the kernel
 - Use `Vararg` to force specialization on `rcopyto_at!`
 - Make `fused_copyto!` return `destinations`, to follow the API of `Base.copyto!`.